### PR TITLE
Fix airflow on k8s operator manager role

### DIFF
--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - certificate.yaml
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,6 +17,9 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - bases/airflow.apache.org_airflowbases.yaml
   - bases/airflow.apache.org_airflowclusters.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,7 +31,7 @@ namePrefix: airflow-on-k8s-operator-
 # commonLabels:
 #  someName: someValue
 
-bases:
+resources:
   - ../crd
   - ../rbac
   - ../manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Adds namespace to all resources.
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Adds namespace to all resources.
 namespace: airflow-on-k8s-operator-system
 
 # Value of this field is prepended to the

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,5 +14,8 @@
 # limitations under the License.
 
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - manager.yaml

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -14,5 +14,8 @@
 # limitations under the License.
 
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - monitor.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 ---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - role.yaml
   - role_binding.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,13 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
-- resources:
-  - configmaps
+- apiGroups:
+  - ""
+  resources:
+    - configmaps
   verbs:
   - create
   - delete
@@ -16,8 +31,8 @@ rules:
   - patch
   - update
   - watch
-- resources:
-  - secrets
+  resources:
+    - secrets
   verbs:
   - create
   - delete
@@ -26,8 +41,8 @@ rules:
   - patch
   - update
   - watch
-- resources:
-  - serviceaccounts
+  resources:
+    - serviceaccounts
   verbs:
   - create
   - delete
@@ -36,8 +51,8 @@ rules:
   - patch
   - update
   - watch
-- resources:
-  - services
+  resources:
+    - services
   verbs:
   - create
   - delete


### PR DESCRIPTION
Updated RBAC for manger-role to address the following error:

The ClusterRole "airflow-on-k8s-operator-manager-role" is invalid: 
* rules[0].apiGroups: Required value: resource rules must supply at least one api group
* rules[1].apiGroups: Required value: resource rules must supply at least one api group
* rules[2].apiGroups: Required value: resource rules must supply at least one api group
* rules[3].apiGroups: Required value: resource rules must supply at least one api group

You can recreate this by running this locally against 1.16 or 1.19 k8s cluster
```shell
kind create cluster --image=kindest/node:v1.16.15 --name airflow 

kustomize build . | kubectl apply -f-
```

Where kustomization.yaml is
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  - git@github.com:apache/airflow-on-k8s-operator/config/default?ref=master
  ```
